### PR TITLE
Created FPS lock.

### DIFF
--- a/pad-dash1.py
+++ b/pad-dash1.py
@@ -31,7 +31,7 @@ class Player:
 
     x = 10
     y = 10
-    speed = .2
+    speed = 8
 
     def moveRight(self):
         self.x += self.speed
@@ -55,7 +55,7 @@ class Padraicula:
 
     x = 801
     y = 601
-    speed = .025
+    speed = 0.5
 
     def moveRight(self):    #these define the movement of the enemy
         self.x += self.speed
@@ -105,6 +105,7 @@ class App:
         self._player_surf = None
         self._pad_surf = None
         self._font_score = None
+        self._clock = None
         self.game = Game()
         self.player = Player()
         self.coin = Coin(5, 5)
@@ -121,6 +122,7 @@ class App:
 
         pygame.init()
         pygame.display.set_caption('Pad-Dash')
+        self._clock = pygame.time.Clock()
         self._running = True
         self._display_surf = pygame.display.set_mode((self.windowWidth, self.windowHeight), pygame.HWSURFACE)
         self._player_surf = pygame.image.load(os.path.join("assets", "test_player_img.png")).convert()
@@ -243,6 +245,9 @@ class App:
 
             self.on_loop()
             self.on_render()
+            self._clock.tick(60)
+            pygame.display.set_caption('Pad-Dash | FPS: {}'.format(str(self._clock.get_fps())))
+
 
         self.on_cleanup()
 

--- a/pad-dash1.py
+++ b/pad-dash1.py
@@ -246,7 +246,7 @@ class App:
             self.on_loop()
             self.on_render()
             self._clock.tick(60)
-            pygame.display.set_caption('Pad-Dash | FPS: {}'.format(str(self._clock.get_fps())))
+            pygame.display.set_caption('Pad-Dash | FPS: {0:.2f}'.format(self._clock.get_fps()))
 
 
         self.on_cleanup()


### PR DESCRIPTION
So, the game actually ran at ~2500 before.

This patch locks the FPS to around 60, and thus, needed speed adjustments to both player and enemies to make it run fine.

This does introduce a small caveat - getting too many coins at the start will cause the enemies to become stuck in one another, and thus, they don't move. However, it does mean less perceived slowdown, because the calculations aren't thus done from 2500 to 800 FPS, it's capped at 60. 